### PR TITLE
fix: 메뉴 상세 조회 Redis 와 함께 사용

### DIFF
--- a/src/main/java/com/latte/menu/controller/MenuController.java
+++ b/src/main/java/com/latte/menu/controller/MenuController.java
@@ -1,5 +1,6 @@
 package com.latte.menu.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.latte.common.response.ResponseData;
 import com.latte.drink.exception.NotEnoughInfoException;
 import com.latte.drink.exception.NotLoginException;
@@ -139,7 +140,7 @@ public class MenuController {
      */
     @GetMapping("/detail/{menuNo}")
     public ResponseEntity<?> menuDetail(@PathVariable Long menuNo,
-                                         @RequestParam(value = "menu_size", defaultValue = "") String menuSize) {
+                                         @RequestParam(value = "menu_size", defaultValue = "") String menuSize) throws JsonProcessingException {
         MemberResponse member;
         ResponseData<?> responseData;
         try {

--- a/src/main/java/com/latte/menu/repository/MenuMapper.java
+++ b/src/main/java/com/latte/menu/repository/MenuMapper.java
@@ -37,9 +37,9 @@ public interface MenuMapper {
 
     List<MenuSimpleResponse> getRecentMenu(@Param("menus") String[] menus);
 
-    MenuDetailResponse getMenuDetail(@Param("no") Long no,
-                                     @Param("menuSize") String menuSize,
-                                     @Param("maxCaffeine") Integer maxCaffeine,
-                                     @Param("brand") String brand,
-                                     @Param("menuName") String menuName);
+    List<MenuDetailResponse> getMenuDetail(@Param("no") Long no,
+                                            @Param("menuSize") String menuSize,
+                                            @Param("maxCaffeine") Integer maxCaffeine);
+
+    String findMenuById(@Param("menuNo") Long menuNo);
 }

--- a/src/main/resources/mapper/MenuMapper.xml
+++ b/src/main/resources/mapper/MenuMapper.xml
@@ -268,13 +268,11 @@
         </association>
         <!-- 낮은 함량의 카페인 -->
         <collection property="lowCaffeineMenus" column="base = CAFFEINE, menuNo = MENU_NO" ofType="MenuSimpleResponse" select="getLowCaffeineMenu"/>
-        <!-- 메뉴의 다른 사이즈 정보 -->
-        <collection property="otherSizes" column="brand = BRAND, menuName = MENU_NAME" ofType="java.lang.String" select="findOtherSizes"/>
     </resultMap>
 
 
     <select id="getMenuDetail" resultMap="menuDetailResultMap">
-        SELECT MENU_NO, BRAND, MENU_NAME, CAFFEINE, PRICE, KCAL, SUGAR, SALT, PROTEIN, SAT_FAT, IMAGE_URL,
+        SELECT MENU_NO, M1.BRAND, M1.MENU_NAME, CAFFEINE, PRICE, KCAL, SUGAR, SALT, PROTEIN, SAT_FAT, IMAGE_URL,
                 CONCAT(MENU_SIZE, '(', SUBSTRING_INDEX(VOLUME, '(', 1), ')') AS MENU_SIZE,
         <!-- 칼로리 높낮이 -->
         CASE
@@ -309,19 +307,14 @@
         <if test="maxCaffeine != null">
             ,CONCAT(ROUND(CAST(SUBSTRING(CAFFEINE, 1, LOCATE('mg', CAFFEINE) - 1) AS UNSIGNED) / #{maxCaffeine} * 100), '%') AS PERCENT
         </if>
-        FROM MENU
-        <where>
-            <!-- 첫 상세 조회 -->
-            <if test="menuSize == null or menuSize == ''">
-                and MENU_NO = #{no}
-            </if>
-            <!-- 상세 조회 후 사이즈 변경 조회 -->
-            <if test="menuSize != null and menuSize != ''">
-                and BRAND = #{brand}
-                and MENU_NAME = #{menuName}
-                and CONCAT(MENU_SIZE, '(', SUBSTRING_INDEX(VOLUME, '(', 1), ')') = #{menuSize}
-            </if>
-        </where>
+        FROM MENU AS M1
+        INNER JOIN (
+            SELECT BRAND, MENU_NAME
+            FROM MENU
+            WHERE MENU_NO = #{no}
+        ) AS M2
+            ON M1.BRAND = M2.BRAND
+                AND M1.MENU_NAME = M2.MENU_NAME
     </select>
 
 
@@ -343,13 +336,11 @@
     </select>
 
 
-    <!-- 메뉴의 다른 사이즈 정보 -->
-    <select id="findOtherSizes" resultType="java.lang.String">
-        SELECT CONCAT(MENU_SIZE, '(', SUBSTRING_INDEX(VOLUME, '(', 1), ')') AS OTHER_MENU_SIZE
+    <!-- 미로그인 사용자를 위한 key 값 찾기 -->
+    <select id="findMenuById" resultType="java.lang.String">
+        SELECT CONCAT(BRAND, '_', MENU_NAME)
         FROM MENU
-        WHERE BRAND = #{brand}
-          AND MENU_NAME = #{menuName}
+        WHERE MENU_NO = #{menuNo}
     </select>
-
 
 </mapper>


### PR DESCRIPTION
### 상세 조회 Redis 와 함께 사용
1. 최초 상세 조회 시, 모든 사이즈에 대한 상세 정보를 DB 에서 조회
2. List 를 반복하며 사이즈 정보 추출 및 통합된 사이즈 정보 저장
3. 완성된 메뉴 상세 정보 Redis 에 Map 형태로 저장 및 사용자 요청 값 찾아서 전달
4. Map 의 key 값은 사이즈 정보

#### 비로그인 사용자
1. 비로그인 사용자는 브랜드명+메뉴명이 key 값
2. 조회 시에는 전달한 ID 값으로 브랜드명+메뉴명 조회 후에 Redis 에서 값을 찾아서 반환

#### 로그인 사용자
1. 로그인 사용자는 key 값이 회원의 ID
2. 조회 시에는 사용자 ID 값을 통해 Redis 에서 값을 찾아서 반환
